### PR TITLE
修复和优化工作流内容

### DIFF
--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -47,10 +47,14 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
-        name: 克隆仓库
+      - name: 克隆仓库
+        uses: actions/checkout@v4.2.0
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          
       - name: 缓存 Cargo 产物
-        uses: actions/cache@v4
+        uses: actions/cache@v4.1.0
         with:
           path: |
             ~/.cargo/bin/
@@ -59,36 +63,44 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          
       - name: 安装 PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: latest
+          
       - name: 安装 Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.4
         with:
           node-version: lts/*
           cache: pnpm
+          
       - name: 安装 Rust 工具链
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          
       - name: 安装 wasm32 目标
         run: rustup target add wasm32-unknown-unknown
+        
       # macOS 自带的 Xcode LLVM 不支持 WASM 目标
       - name: "macOS: 安装 LLVM 和 Clang"
         uses: KyleMayes/install-llvm-action@v2
         if: matrix.platform == 'macos-latest'
         with:
           version: "15"
+          
       - name: 安装 Tauri 所需系统依赖（仅 Linux）
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libasound2-dev libappindicator3-dev libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          
       - name: 安装前端依赖
         run: pnpm i
+        
       - name: 构建 AMLL TTML Tools 程序并发布自动构建
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.5.15
         with:
           tagName: ${{ github.ref_name }}-dev
           includeUpdaterJson: true
@@ -104,8 +116,9 @@ jobs:
           args: ${{ matrix.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: 上传产物到 Action Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: AMLL TTML Tools ${{matrix.name}}-${{matrix.arch}}
           path: |

--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -1,9 +1,11 @@
 name: 构建网页版本并部署到 Github Pages
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -12,24 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 克隆仓库源代码
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4.2.0
         with:
           submodules: recursive
+          fetch-depth: 0
+          
       - name: 安装 PNPM
         uses: pnpm/action-setup@v4
         with:
           version: latest
+          
       - name: 安装 Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.4
         with:
           node-version: lts/*
           cache: pnpm
-      - name: 配置 NodeJS
-        uses: actions/setup-node@v3.0.0
+          
       - name: 安装前端依赖
         run: pnpm i
+        
       - name: 构建网页版本
         run: pnpm build
+        
       - name: 部署到 Github Pages
         uses: crazy-max/ghaction-github-pages@v2.6.0
         with:

--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           
       - name: 安装 PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: latest
           
@@ -37,7 +37,7 @@ jobs:
         run: pnpm build
         
       - name: 部署到 Github Pages
-        uses: crazy-max/ghaction-github-pages@v2.6.0
+        uses: crazy-max/ghaction-github-pages@v4.0.0
         with:
           target_branch: gh-pages
           build_dir: dist


### PR DESCRIPTION
修复了桌面版编译前端时报错找不到`kuromoji.js`的问题；但是`macOS`下报错`times`版本不兼容的问题还未解决，可能是跟`Tauri`版本有关，但是对它不熟，暂时还没法修复了😅（Windows和Linux已经可以正常打包了）
顺便优化了构建网页端的工作流内容，变得更加精简了

一起升级了工作流的运行依赖，如`checkout`之类的

运行结果可以在[这里](https://github.com/Super12138/amll-ttml-tool/actions/)看到（上传release报错是由于fork仓库后没有添加release-tag，实际合并后应该没问题）