### PR TITLE
禁用 Dark Reader 浏览器扩展

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <link rel="apple-touch-icon" sizes="120x120" href="./src/assets/logo.png">
   <link rel="apple-touch-icon" sizes="152x152" href="./src/assets/logo.png">
   <title>AMLL TTML Tool</title>
+  <meta name="darkreader-lock">
   <style>
     * {
       margin: 0;


### PR DESCRIPTION
Dark Reader 是一个被广泛使用的，用于强制网页以深色渲染的浏览器插件。我们已经实现了深色支持，所以应当声明禁用该浏览器扩展以阻止意外的样式变更。

参考：https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-statically