### PR TITLE
修复无法在低于 Windows 11 的系统上启动的 Bug

### DIFF
--- a/src-tauri/capabilities/default.toml
+++ b/src-tauri/capabilities/default.toml
@@ -28,6 +28,8 @@ identifier = "core:window:allow-maximize"
 [[permissions]]
 identifier = "core:window:allow-unmaximize"
 [[permissions]]
+identifier = "core:window:allow-set-effects"
+[[permissions]]
 identifier = "decorum:allow-show-snap-overlay"
 [[permissions]]
 identifier = "shell:allow-open"


### PR DESCRIPTION
修复未授予对应权限导致的无法启动问题

相关的 Issue: https://github.com/Steve-xmh/amll-ttml-tool/issues/53