### PR TITLE
fix: 在合并单词时正确设置结束时间

### DIFF
--- a/src/components/LyricLinesView/lyric-word-menu.tsx
+++ b/src/components/LyricLinesView/lyric-word-menu.tsx
@@ -66,28 +66,34 @@ export const LyricWordMenu = ({
 						const selectedWords = store.get(selectedWordsAtom);
 						const line = state.lyricLines[lineIndex];
 						if (line) {
-							let firstIndex = -1;
-							let mergedWord = "";
-							for (const w of line.words) {
-								if (selectedWords.has(w.id)) {
-									mergedWord += w.word;
-									if (firstIndex === -1) {
-										firstIndex = line.words.indexOf(w);
-									}
-								}
-							}
-							const newWord = newLyricWord();
-							newWord.word = mergedWord;
-							newWord.startTime = line.words[wordIndex].startTime;
-							state.lyricLines[lineIndex].words = line.words.filter(
-								(w) => !selectedWords.has(w.id),
+							const selectedWordsInLine = line.words.filter((w) =>
+								selectedWords.has(w.id),
 							);
-							if (firstIndex !== -1) {
-								state.lyricLines[lineIndex].words.splice(
-									firstIndex,
-									0,
-									newWord,
+
+							if (selectedWordsInLine.length > 1) {
+								const mergedWord = selectedWordsInLine
+									.map((w) => w.word)
+									.join("");
+								const firstWord = selectedWordsInLine[0];
+								const lastWord =
+									selectedWordsInLine[selectedWordsInLine.length - 1];
+								const firstIndex = line.words.indexOf(firstWord);
+
+								const newWord = newLyricWord();
+								newWord.word = mergedWord;
+								newWord.startTime = firstWord.startTime;
+								newWord.endTime = lastWord.endTime;
+
+								state.lyricLines[lineIndex].words = line.words.filter(
+									(w) => !selectedWords.has(w.id),
 								);
+								if (firstIndex !== -1) {
+									state.lyricLines[lineIndex].words.splice(
+										firstIndex,
+										0,
+										newWord,
+									);
+								}
 							}
 						}
 					});


### PR DESCRIPTION
修复 #83 

在合并单词时，没有设置结束时间，导致结束时间是默认的 `00:00.000`