### PR TITLE
元数据编辑器小改动

### DIFF
--- a/src/components/Dialogs/metadata.tsx
+++ b/src/components/Dialogs/metadata.tsx
@@ -504,6 +504,8 @@ export const MetadataEditor = () => {
 				),
 				value: "ttmlAuthorGithub",
 				icon: <GithubIcon />,
+				isLinkable: true,
+				urlFormatter: (val) => getPlatformUrl("ttmlAuthorGithub", val),
 				validation: {
 					verifier: numeric,
 					message: t(


### PR DESCRIPTION
- Apple Music 的跳转 URL 修改为 `https://beta.music.apple.com`；
- `歌词作者 GitHub ID` 增加跳转按钮，链接为 `https://api.github.com/user/`。